### PR TITLE
Declare dependency on Rhtslib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Encoding: UTF-8
 License: GPL-3
 LazyData: true
 Suggests: 
+    Rhtslib,
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
Your `Makevars` file calls a function from Rhtslib but you have not declared this package anywhere.
Therefore it fails to install: https://github.com/r-universe/cran/actions/runs/14430397043/job/40470522685